### PR TITLE
Avoid overflow by restricting modulo to int

### DIFF
--- a/Dlang/Math/math.d
+++ b/Dlang/Math/math.d
@@ -77,7 +77,7 @@ void combTable(double[] d, long n) {
         d[i] = d[i-1]*(n-i+1)/i;
     }
 }
-long combMod(long n, long k, long md) {
+long combMod(long n, long k, int md) {
     assert(k < md);
     n %= md;
     if (n < k || k < 0) return 0;
@@ -94,7 +94,7 @@ long combMod(long n, long k, long md) {
     return r;
 }
 
-long lucas(long n, long k, long md) {
+long lucas(long n, long k, int md) {
     if (n < k) return 0;
     long res = 1;
     while (n) {


### PR DESCRIPTION
c3b1e68eb18b6f2235f9dd584cdce62967f07d73 further needs this change.
